### PR TITLE
Fix typo in getting-started/3-improving

### DIFF
--- a/getting-started/3-improving.md
+++ b/getting-started/3-improving.md
@@ -56,7 +56,7 @@ void main() {
     vec4 lightColor = texture(lightmap, lightCoord);
     
     // Calculate our new fog color!
-    float fogValue = vertexPosition < fogEnd ? smoothstep(fogStart, fogEnd, vertexPosition) : 1.0;
+    float fogValue = vertexDistance < fogEnd ? smoothstep(fogStart, fogEnd, vertexDistance) : 1.0;
 
     vec4 finalColor = texColor * lightColor * vertexColor;
     pixelColor = vec4(mix(finalColor.xyz, fogColor, fogValue), finalColor.a);


### PR DESCRIPTION
In getting-started/3-improving.md, fix where it said vertexPosition in the fragment shader example where it was supposed to be vertexDistance